### PR TITLE
Fix deletion of too many chars on insert

### DIFF
--- a/helm-company.el
+++ b/helm-company.el
@@ -178,6 +178,7 @@ It is useful to narrow candidates."
   (unless company-candidates
     (company-complete))
   (when company-point
+    (company-complete-common)
     (helm :sources 'helm-source-company
           :buffer  "*helm company*"
           :candidate-number-limit helm-company-candidate-number-limit)))


### PR DESCRIPTION
When `helm-company` is initiated before all the common part is completed, it deletes that many chars before completion point.

![output](https://cloud.githubusercontent.com/assets/2280844/15305712/7acb9314-1bcd-11e6-9554-77bdbf9da19f.gif)
