### PR TITLE
Revert "Fix deletion of too many chars upon insert"

### DIFF
--- a/helm-company.el
+++ b/helm-company.el
@@ -184,7 +184,6 @@ It is useful to narrow candidates."
   (unless company-candidates
     (company-complete))
   (when company-point
-    (company-complete-common)
     (helm :sources 'helm-source-company
           :buffer  "*helm company*"
           :candidate-number-limit helm-company-candidate-number-limit)))


### PR DESCRIPTION
This reverts commit 439fa29265da9cf705a1057b9aaf3373607e7a47.

Since 259c1a4 implemented a better way of candidate insertion, my
workaround no longer relevant and does not work well with the new
implementation: extra prefix is being left in place before the selected
candidate.